### PR TITLE
[BUGFIXING] Email variables are not working when sending a test email

### DIFF
--- a/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-1.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-1.php
@@ -148,6 +148,22 @@ class PMPro_Email_Template_PMProACR_Reminder_1 extends PMPro_Email_Template {
 		$user = $this->user;
 		return empty( $user->display_name ) ? esc_html__( 'User', 'pmpro-abandoned-cart-recovery' ) : $user->display_name;
 	}
+
+	/**
+	 * Returns the arguments to send the test email from the abstract class.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The arguments to send the test email from the abstract class.
+	 */
+	public static function get_test_email_constructor_args() {
+		global $current_user;
+		$pmpro_test_level = new StdClass();
+		$pmpro_test_level->id = 1;
+		$pmpro_test_level->name = esc_html__( 'Test Level', 'pmpro-abandoned-cart-recovery' );
+
+		return array( $current_user, $pmpro_test_level );
+	}
 }
 /**
  * Register the email template.

--- a/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-1.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-1.php
@@ -97,14 +97,9 @@ class PMPro_Email_Template_PMProACR_Reminder_1 extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'!!user_login!!' => esc_html__( 'The user\'s login name.', 'pmpro-abandoned-cart-recovery' ),
-			'!!user_email!!' => esc_html__( 'The user\'s email address.', 'pmpro-abandoned-cart-recovery' ),
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-abandoned-cart-recovery' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-abandoned-cart-recovery' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-abandoned-cart-recovery' ),
 			'!!checkout_url!!' => esc_html__( 'The URL to the checkout page.', 'pmpro-abandoned-cart-recovery' ),
 			'!!opt_out_url!!' => esc_html__( 'The URL to opt out of future emails.', 'pmpro-abandoned-cart-recovery' ),
-
 		);
 	}
 
@@ -126,7 +121,6 @@ class PMPro_Email_Template_PMProACR_Reminder_1 extends PMPro_Email_Template {
 			'membership_id' => $level->id,
 			'membership_level_name' => $level->name,
 			'checkout_url' => pmpro_login_url( pmpro_url( 'checkout', '?pmpro_level=' . $level->id ) ),
-			'levels_url' => pmpro_login_url( pmpro_url( 'levels' ) ),
 			'opt_out_url' => add_query_arg( 'pmproacr_opt_out', urlencode( $user->user_email ), home_url() ),
 		);
 		return $email_template_variables;

--- a/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-2.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-2.php
@@ -149,6 +149,22 @@ class PMPro_Email_Template_PMProACR_Reminder_2 extends PMPro_Email_Template {
 		$user = $this->user;
 		return empty( $user->display_name ) ? esc_html__( 'User', 'pmpro-abandoned-cart-recovery' ) : $user->display_name;
 	}
+
+	/**
+	 * Returns the arguments to send the test email from the abstract class.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The arguments to send the test email from the abstract class.
+	 */
+	public static function get_test_email_constructor_args() {
+		global $current_user;
+		$pmpro_test_level = new StdClass();
+		$pmpro_test_level->id = 1;
+		$pmpro_test_level->name = esc_html__( 'Test Level', 'pmpro-abandoned-cart-recovery' );
+
+		return array( $current_user, $pmpro_test_level );
+	}
 }
 /**
  * Register the email template.

--- a/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-2.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-2.php
@@ -98,14 +98,9 @@ class PMPro_Email_Template_PMProACR_Reminder_2 extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'!!user_login!!' => esc_html__( 'The user\'s login name.', 'pmpro-abandoned-cart-recovery' ),
-			'!!user_email!!' => esc_html__( 'The user\'s email address.', 'pmpro-abandoned-cart-recovery' ),
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-abandoned-cart-recovery' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-abandoned-cart-recovery' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-abandoned-cart-recovery' ),
 			'!!checkout_url!!' => esc_html__( 'The URL to the checkout page.', 'pmpro-abandoned-cart-recovery' ),
 			'!!opt_out_url!!' => esc_html__( 'The URL to opt out of future emails.', 'pmpro-abandoned-cart-recovery' ),
-
 		);
 	}
 

--- a/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-3.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-3.php
@@ -95,14 +95,8 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 	 */
 	public static function get_email_template_variables_with_description() {
 		return array(
-			'!!user_login!!' => esc_html__( 'The user\'s login name.', 'pmpro-abandoned-cart-recovery' ),
-			'!!user_email!!' => esc_html__( 'The user\'s email address.', 'pmpro-abandoned-cart-recovery' ),
-			'!!display_name!!' => esc_html__( 'The user\'s display name.', 'pmpro-abandoned-cart-recovery' ),
-			'!!membership_id!!' => esc_html__( 'The ID of the membership level.', 'pmpro-abandoned-cart-recovery' ),
 			'!!membership_level_name!!' => esc_html__( 'The name of the membership level.', 'pmpro-abandoned-cart-recovery' ),
 			'!!checkout_url!!' => esc_html__( 'The URL to the checkout page.', 'pmpro-abandoned-cart-recovery' ),
-			'!!opt_out_url!!' => esc_html__( 'The URL to opt out of future emails.', 'pmpro-abandoned-cart-recovery' ),
-
 		);
 	}
 
@@ -124,7 +118,6 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 			'membership_id' => $level->id,
 			'membership_level_name' => $level->name,
 			'checkout_url' => pmpro_login_url( pmpro_url( 'checkout', '?pmpro_level=' . $level->id ) ),
-			'opt_out_url' => add_query_arg( 'pmproacr_opt_out', urlencode( $user->user_email ), home_url() ),
 		);
 		return $email_template_variables;
 	}

--- a/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-3.php
+++ b/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-3.php
@@ -144,6 +144,22 @@ class PMPro_Email_Template_PMProACR_Reminder_3 extends PMPro_Email_Template {
 		$user = $this->user;
 		return empty( $user->display_name ) ? esc_html__( 'User', 'pmpro-abandoned-cart-recovery' ) : $user->display_name;
 	}
+
+	/**
+	 * Returns the arguments to send the test email from the abstract class.
+	 *
+	 * @since TBD
+	 *
+	 * @return array The arguments to send the test email from the abstract class.
+	 */
+	public static function get_test_email_constructor_args() {
+		global $current_user;
+		$pmpro_test_level = new StdClass();
+		$pmpro_test_level->id = 1;
+		$pmpro_test_level->name = esc_html__( 'Test Level', 'pmpro-abandoned-cart-recovery' );
+
+		return array( $current_user, $pmpro_test_level );
+	}
 }
 /**
  * Register the email template.

--- a/includes/emails.php
+++ b/includes/emails.php
@@ -94,13 +94,75 @@ function pmproacr_send_reminder_email( $recovery_attempt, $reminder_number ) {
  * @since TBD
  */
 function pmproacr_init_email_templates() {
-	if ( class_exists( 'PMPro_Email_Template' ) ) {
-		require_once( PMPROACR_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-1.php' );
-		require_once( PMPROACR_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-2.php' );
-		require_once( PMPROACR_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-3.php' );
-	} else {
-		// Legacy email templates.
-		add_filter( 'pmproet_templates', 'pmproacr_email_templates' );
-	}
+    if ( class_exists( 'PMPro_Email_Template' ) ) {
+        require_once( PMPROACR_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-1.php' );
+        require_once( PMPROACR_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-2.php' );
+        require_once( PMPROACR_DIR . '/classes/email-templates/class-pmpro-email-template-pmpro-abandoned-cart-recovery-reminder-3.php' );
+        // Add the filter to send the test emails.
+        add_filter( 'pmpro_email_template_send_test_email', 'pmproacr_send_test_email', 10, 2 );
+        add_filter( 'pmpro_email_template_send_test_email_params', 'pmproacr_send_test_email_params', 10, 2 );
+    } else {
+        // Legacy email templates.
+        add_filter( 'pmproet_templates', 'pmproacr_email_templates' );
+    }
 }
 add_action( 'init', 'pmproacr_init_email_templates', 8 );
+
+
+/**
+ * Filters send test email params callback.
+ * 
+ * @param array $params The original parameters.
+ * @param string $template The original template.
+ * @return array The parameters.
+ * @since TBD
+ */
+function pmproacr_send_test_email_params( $params, $template ) {
+    $fake_user = new WP_User( 1, 'testuser', 'test@test.com' );
+    $fake_user->display_name = 'Test User';
+    $params['user'] = $fake_user;
+
+    $fake_level = new stdClass();
+    $fake_level->name = 'Test Level';
+    $fake_level->id = 1;
+    $params['level'] = $fake_level;
+
+    $params['reminder_number'] = str_replace( 'pmproacr_reminder_', '', $template );
+
+    $params['user'] = $fake_user;
+    $params['level'] = $fake_level;
+
+    return $params;
+}
+
+/**
+ * Filters send test email callback.
+ * 
+ * @param string $email The original email.
+ * @param array $params The original parameters.
+ * @return string The name of the function to call.
+ * @since TBD
+ */
+function pmproacr_send_test_email( $email, $params ) {
+    return 'send_abandoned_cart_recovery_reminder_email_test';
+}
+
+/**
+ * Sends a test email.
+ * 
+ * @param object $user The user.
+ * @param object $level The level.
+ * @param int $reminder_number The reminder number.
+ * @return bool True if the email was sent, false otherwise.
+ * @since TBD
+ */
+function send_abandoned_cart_recovery_reminder_email_test( $user, $level, $reminder_number ) {
+    //pmproacr_send_test_email and pmproacr_send_test_email_params filters were added after v3.4+ but just in case.
+    if( ! class_exists( 'PMPro_Email_Template' ) ) {
+        return false;
+    }
+
+    $class_name = 'PMPro_Email_Template_PMProACR_Reminder_' . $reminder_number;
+    $send_email = new $class_name( $user, $level );
+    return $send_email->send();
+}


### PR DESCRIPTION
 * Filter pmpro_email_templates_send_test send_email and params function and send a custom test email.
 
 Needs https://github.com/strangerstudios/paid-memberships-pro/pull/3338 to work.

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-abandoned-cart-recovery/pulls/) for the same update/change?

### Changes proposed in this Pull Request:

Resolves #5

### How to test the changes in this Pull Request:

Follow steps described in the issue #5 if this  patch  and https://github.com/strangerstudios/paid-memberships-pro/pull/3338 are applied should work properly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
